### PR TITLE
Add configurable stop condition for recursive schemas

### DIFF
--- a/encoding/openapi/cycle.go
+++ b/encoding/openapi/cycle.go
@@ -26,16 +26,23 @@ import (
 func (b *builder) pushNode(v cue.Value) {
 	_, n := internalvalue.ToInternal(v)
 	b.ctx.cycleNodes = append(b.ctx.cycleNodes, n)
+	b.ctx.evalDepth++
 }
 
 func (b *builder) popNode() {
 	b.ctx.cycleNodes = b.ctx.cycleNodes[:len(b.ctx.cycleNodes)-1]
+	b.ctx.evalDepth--
 }
 
 func (b *builder) checkCycle(v cue.Value) bool {
 	if !b.ctx.expandRefs {
 		return true
 	}
+
+	if b.ctx.maxCycleDepth > 0 && b.ctx.evalDepth > b.ctx.maxCycleDepth {
+		return false
+	}
+
 	r, n := internalvalue.ToInternal(v)
 	ctx := eval.NewContext(r, n)
 

--- a/encoding/openapi/openapi.go
+++ b/encoding/openapi/openapi.go
@@ -81,6 +81,12 @@ type Config struct {
 	// OpenAPI Schema. It is an error for an CUE value to refer to itself
 	// if this option is used.
 	ExpandReferences bool
+
+	// MaxCycleDepth is a value that adds a maximum of iterations to stop evaluating
+	// structure cycles. The current behaviour does not have any stop condition, and it could
+	// generate infinite loops working with recursive values.
+	// The value should be big enough to fix the desire use case, but it must be used carefully.
+	MaxCycleDepth int
 }
 
 type Generator = Config

--- a/encoding/openapi/openapi.go
+++ b/encoding/openapi/openapi.go
@@ -82,10 +82,13 @@ type Config struct {
 	// if this option is used.
 	ExpandReferences bool
 
-	// MaxCycleDepth is a value that adds a maximum of iterations to stop evaluating
-	// structure cycles. The current behaviour does not have any stop condition, and it could
-	// generate infinite loops working with recursive values.
-	// The value should be big enough to fix the desire use case, but it must be used carefully.
+	// MaxCycleDepth specifies the maximum number of steps to search for structural
+	// cycles.
+	//
+	// This is a hack, not a general purpose solution to cycle detection. Use it
+	// with care. Set a value large enough to capture known use cases.
+	//
+	// NOTE This option does not exist in canonical cue-lang/cue.
 	MaxCycleDepth int
 }
 


### PR DESCRIPTION
Openapi doesn't have any stop condition for complex recursive schemas and generates infinite loops.

This PR adds a dummy way to add a stop condition. Mainly it adds a configurable value that indicates the maximum depth of cycle iteration. When it reaches the maximum value, it returns and prints the current result of the schema.

This new approach only works when MaxCycleDepth has a value bigger than 0.