### PR TITLE
Handle schema subsumption with built-in validators

### DIFF
--- a/internal/core/subsume/value.go
+++ b/internal/core/subsume/value.go
@@ -81,6 +81,24 @@ func (s *subsumer) values(a, b adt.Value) (result bool) {
 		// TODO: this would work better if all equal nodes shared the same
 		// node link.
 		return deref(a) == deref(b)
+
+	case *adt.BuiltinValidator:
+		if x, ok := a.(*adt.BuiltinValidator); ok {
+			if x.Builtin.Name != b.Builtin.Name {
+				return false
+			}
+
+			for i, y := range b.Args {
+				if len(x.Args) <= i {
+					return false
+				}
+
+				if !s.values(x.Args[i], y) {
+					return false
+				}
+			}
+			return true
+		}
 	}
 
 	switch x := a.(type) {


### PR DESCRIPTION
This adds a new case in subsume value comparison to handle schema field comparison containing constraints like:
```
aString: string & strings.MinRunes(1)
```

Issue created in the upstream repo: https://github.com/cue-lang/cue/issues/2419