### PR TITLE
Set proper format when we have a nullable number

### DIFF
--- a/encoding/openapi/testdata/nums-v3.1.0.json
+++ b/encoding/openapi/testdata/nums-v3.1.0.json
@@ -21,8 +21,7 @@
          },
          "intNull": {
             "type": "integer",
-            "minimum": -9223372036854775808,
-            "maximum": 9223372036854775807,
+            "format": "int64",
             "nullable": true
          },
          "mul": {
@@ -45,3 +44,4 @@
       }
    }
 }
+

--- a/encoding/openapi/testdata/nums.json
+++ b/encoding/openapi/testdata/nums.json
@@ -23,8 +23,7 @@
          },
          "intNull": {
             "type": "integer",
-            "minimum": -9223372036854775808,
-            "maximum": 9223372036854775807,
+            "format": "int64",
             "nullable": true
          },
          "mul": {

--- a/encoding/openapi/types.go
+++ b/encoding/openapi/types.go
@@ -17,12 +17,11 @@ package openapi
 import (
 	"fmt"
 
-	"github.com/cockroachdb/apd/v3"
-
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/ast"
 	"cuelang.org/go/cue/literal"
 	"cuelang.org/go/cue/token"
+	"github.com/cockroachdb/apd/v3"
 )
 
 // See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#data-types
@@ -59,10 +58,17 @@ func extractFormat(v cue.Value) string {
 	}
 	var arg string
 
-	if op, a := v.Expr(); op == cue.CallOp {
+	op, a := v.Expr()
+
+	switch op {
+	case cue.CallOp:
 		v = a[0]
 		if len(a) == 2 {
 			arg = fmt.Sprintf(" (%v)", a[1].Eval())
+		}
+	case cue.OrOp:
+		if len(a) == 2 && a[1].Kind() == cue.NullKind {
+			v = a[0]
 		}
 	}
 


### PR DESCRIPTION
This [map](https://github.com/sdboyer/cue/blob/master/encoding/openapi/types.go#L29) is the one that decides the format of each field and we are passing the pattern `xxx | null`. In these cases, we aren't removing the null and the format is always null.

Extracting the first value, we can set the format and the code, automatically removes `minimum` and `maximum` tags from the resulting json.